### PR TITLE
Test: Correct ESLint test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "eslint-test": "npx eslint $1"
+    "eslint-test": "npx eslint"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The idea was to pass an argument when using the command: (the file would be the argument)

```
npx eslint $1
```

It wasn't working properly.
There are other ways of doing it but that could get more complex.

With the script like: `npx eslint` and the command to run:

```
npm run-script eslint-test file-name
```

gives the expected result without opening for errors.
The script `npx eslint` is there so anyone know how to run the ESLint.